### PR TITLE
fix(train): switch validation to step-based interval

### DIFF
--- a/configs/resplan_housediff_def.yaml
+++ b/configs/resplan_housediff_def.yaml
@@ -21,7 +21,7 @@ training:
   save_interval: 10000
   log_interval: 100
   lr_decay_steps: 100000
-  check_val_every_n_epoch: 40
+  val_check_interval: 10000
 
 data:
   pickle_path: data/raw/ResPlan.pkl

--- a/configs/resplan_housediff_stable_fp32.yaml
+++ b/configs/resplan_housediff_stable_fp32.yaml
@@ -18,7 +18,7 @@ training:
   save_interval: 25000
   log_interval: 10
   lr_decay_steps: 100000
-  check_val_every_n_epoch: 40
+  val_check_interval: 25000
 
 data:
   pickle_path: data/raw/ResPlan.pkl

--- a/configs/resplan_housediff_test.yaml
+++ b/configs/resplan_housediff_test.yaml
@@ -22,7 +22,7 @@ training:
   save_interval: 250
   log_interval: 10
   lr_decay_steps: 100000
-  check_val_every_n_epoch: 5
+  val_check_interval: 250
 
 data:
   pickle_path: data/raw/ResPlan.pkl

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -32,13 +32,13 @@ logger = logging.getLogger(__name__)
 
 # Room-type int → colour for rendering.
 ROOM_COLORS: dict[int, str] = {
-    1:  "#EE4D4D",   # living
-    2:  "#C67C7B",   # bedroom
-    3:  "#FFD274",   # kitchen
-    4:  "#BEBEBE",   # bathroom
-    10: "#1F849B",   # balcony
-    11: "#E78AC3",   # door (interior)
-    13: "#A63603",   # front_door
+    1: "#EE4D4D",  # living
+    2: "#C67C7B",  # bedroom
+    3: "#FFD274",  # kitchen
+    4: "#BEBEBE",  # bathroom
+    10: "#1F849B",  # balcony
+    11: "#E78AC3",  # door (interior)
+    13: "#A63603",  # front_door
 }
 
 INT_TO_ROOM_NAME: dict[int, str] = {v: k for k, v in ROOM_TYPE_TO_INT.items()}
@@ -106,9 +106,15 @@ def render_floorplan(
         color = ROOM_COLORS.get(rtype, "#888888")
         label = INT_TO_ROOM_NAME.get(rtype, f"type_{rtype}")
         if len(coords) >= 3:
-            poly = plt.Polygon(coords, closed=True, facecolor=color,
-                               edgecolor="black", linewidth=1.0, alpha=0.7,
-                               label=label)
+            poly = plt.Polygon(
+                coords,
+                closed=True,
+                facecolor=color,
+                edgecolor="black",
+                linewidth=1.0,
+                alpha=0.7,
+                label=label,
+            )
             ax.add_patch(poly)
         # Draw corner markers.
         ax.scatter(coords[:, 0], coords[:, 1], s=10, c="black", zorder=5)
@@ -167,11 +173,13 @@ def compute_graph_accuracy_from_points(
                 continue
             # Pick a representative point from each room.
             pa = next(
-                i for i in range(100)
+                i
+                for i in range(100)
                 if padding_mask[i] < 0.5 and int(np.argmax(room_indices[i])) == ra
             )
             pb = next(
-                i for i in range(100)
+                i
+                for i in range(100)
                 if padding_mask[i] < 0.5 and int(np.argmax(room_indices[i])) == rb
             )
             if door_mask[pa, pb] < 0.5:
@@ -186,7 +194,7 @@ def compute_graph_accuracy_from_points(
         pts_b = ridx_to_pts[rb]
         # Minimum pairwise distance.
         diffs = pts_a[:, None, :] - pts_b[None, :, :]
-        dists = np.sqrt((diffs ** 2).sum(axis=-1))
+        dists = np.sqrt((diffs**2).sum(axis=-1))
         if dists.min() < adjacency_threshold:
             satisfied += 1
 
@@ -280,15 +288,21 @@ def main() -> None:
     """Entry point for sampling."""
     parser = argparse.ArgumentParser(description="Sample floorplans from a trained model")
     parser.add_argument(
-        "--checkpoint", type=str, required=True,
+        "--checkpoint",
+        type=str,
+        required=True,
         help="Path to a Lightning checkpoint (.ckpt)",
     )
     parser.add_argument(
-        "--pickle_path", type=str, default="data/raw/ResPlan.pkl",
+        "--pickle_path",
+        type=str,
+        default="data/raw/ResPlan.pkl",
         help="Path to ResPlan pickle (for conditioning data)",
     )
     parser.add_argument(
-        "--cache_dir", type=str, default="data/processed",
+        "--cache_dir",
+        type=str,
+        default="data/processed",
         help="Cache directory for processed tensors",
     )
     parser.add_argument("--num_samples", type=int, default=8, help="How many to generate")
@@ -296,7 +310,9 @@ def main() -> None:
     parser.add_argument("--output_dir", type=str, default="outputs", help="Output directory")
     parser.add_argument("--device", type=str, default="auto", help="Device (cpu/cuda/auto)")
     parser.add_argument(
-        "--analog_bit", action="store_true", default=False,
+        "--analog_bit",
+        action="store_true",
+        default=False,
         help="Use analog mode (default: binary)",
     )
     args = parser.parse_args()
@@ -361,8 +377,11 @@ def main() -> None:
         # Generate.
         logger.info("Generating batch %d–%d ...", sample_idx, batch_end - 1)
         generated = generate_samples(
-            model, diffusion, cond_batch,
-            analog_bit=args.analog_bit, device=device,
+            model,
+            diffusion,
+            cond_batch,
+            analog_bit=args.analog_bit,
+            device=device,
         )
         generated_np = generated.cpu().numpy()  # [batch, 2, 100]
 
@@ -380,15 +399,24 @@ def main() -> None:
 
             # Build polygons.
             gen_polys = points_to_room_polygons(
-                gen_points, room_types, room_indices, padding_mask,
+                gen_points,
+                room_types,
+                room_indices,
+                padding_mask,
             )
             gt_polys = points_to_room_polygons(
-                gt_points, room_types, room_indices, padding_mask,
+                gt_points,
+                room_types,
+                room_indices,
+                padding_mask,
             )
 
             # Graph accuracy.
             accuracy = compute_graph_accuracy_from_points(
-                gen_points, door_mask, room_indices, padding_mask,
+                gen_points,
+                door_mask,
+                room_indices,
+                padding_mask,
             )
             all_accuracies.append(accuracy)
 
@@ -401,8 +429,7 @@ def main() -> None:
             handles, labels = axes[1].get_legend_handles_labels()
             seen = set()
             unique = [
-                (h, lab) for h, lab in zip(handles, labels)
-                if lab not in seen and not seen.add(lab)
+                (h, lab) for h, lab in zip(handles, labels) if lab not in seen and not seen.add(lab)
             ]
             if unique:
                 fig.legend(*zip(*unique), loc="lower center", ncol=len(unique), fontsize=9)
@@ -412,7 +439,9 @@ def main() -> None:
             plt.close(fig)
             logger.info(
                 "  [%d] graph_accuracy=%.2f  saved to %s",
-                idx, accuracy, output_dir / f"sample_{idx:04d}.png",
+                idx,
+                accuracy,
+                output_dir / f"sample_{idx:04d}.png",
             )
 
         sample_idx = batch_end
@@ -423,7 +452,9 @@ def main() -> None:
         std_acc = np.std(all_accuracies)
         logger.info(
             "Graph accuracy: %.4f ± %.4f  (n=%d)",
-            mean_acc, std_acc, len(all_accuracies),
+            mean_acc,
+            std_acc,
+            len(all_accuracies),
         )
     logger.info("Sampling complete. Outputs in %s", output_dir)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -128,11 +128,15 @@ def main() -> None:
     """Entry point for training."""
     parser = argparse.ArgumentParser(description="Train floorplan diffusion model")
     parser.add_argument(
-        "--config", type=str, required=True,
+        "--config",
+        type=str,
+        required=True,
         help="Path to YAML config file (e.g. configs/resplan_housediff.yaml)",
     )
     parser.add_argument(
-        "--resume", type=str, default=None,
+        "--resume",
+        type=str,
+        default=None,
         help="Path to checkpoint to resume training from",
     )
     args, remaining = parser.parse_known_args()

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -199,7 +199,7 @@ def main() -> None:
     # --- Trainer ---
     trainer = pl.Trainer(
         max_steps=train_cfg["max_steps"],
-        check_val_every_n_epoch=train_cfg["check_val_every_n_epoch"],
+        val_check_interval=train_cfg["val_check_interval"],
         callbacks=callbacks,
         logger=csv_logger,
         log_every_n_steps=train_cfg["log_interval"],

--- a/src/floorplan_diffusion/data/dataset.py
+++ b/src/floorplan_diffusion/data/dataset.py
@@ -98,7 +98,7 @@ def _get_any_geoms(geom_data: Any) -> list[Any]:
     if hasattr(geom_data, "geoms"):
         return [
             g for g in geom_data.geoms if isinstance(g, (Polygon, LineString)) and not g.is_empty
-        ]  # noqa: E501
+        ]
     return []
 
 

--- a/src/floorplan_diffusion/data/dataset.py
+++ b/src/floorplan_diffusion/data/dataset.py
@@ -36,7 +36,7 @@ ROOM_TYPES: list[str] = ["living", "bedroom", "kitchen", "bathroom", "balcony"]
 """Canonical ordering of room types when iterating a plan."""
 
 DOOR_TYPES: dict[str, int] = {
-    "door": 11,        # interior door opening  (matches RPLAN type 11)
+    "door": 11,  # interior door opening  (matches RPLAN type 11)
     "front_door": 13,  # building entry door    (matches RPLAN type 13)
 }
 """Mapping from ResPlan door-geometry keys to RPLAN integer encoding."""
@@ -96,7 +96,9 @@ def _get_any_geoms(geom_data: Any) -> list[Any]:
     if isinstance(geom_data, (Polygon, LineString)):
         return [] if geom_data.is_empty else [geom_data]
     if hasattr(geom_data, "geoms"):
-        return [g for g in geom_data.geoms if isinstance(g, (Polygon, LineString)) and not g.is_empty]
+        return [
+            g for g in geom_data.geoms if isinstance(g, (Polygon, LineString)) and not g.is_empty
+        ]  # noqa: E501
     return []
 
 
@@ -309,7 +311,8 @@ class ResPlanDataset(Dataset):
             if len(corners) > 32:
                 logger.debug(
                     "Room %s has %d corners (>32); rejecting plan.",
-                    node_id, len(corners),
+                    node_id,
+                    len(corners),
                 )
                 return None
 
@@ -336,7 +339,7 @@ class ResPlanDataset(Dataset):
 
             # Room index is 1-indexed (first room -> index 1).
             room_idx_oh = np.tile(_get_one_hot(len(house_parts) + 1, 32), (num_room_corners, 1))
-                
+
             corner_idx_oh = np.array([_get_one_hot(c, 32) for c in range(num_room_corners)])
 
             # Padding mask: 1 for real points.

--- a/src/floorplan_diffusion/training/data_module.py
+++ b/src/floorplan_diffusion/training/data_module.py
@@ -59,9 +59,7 @@ class ResPlanDataModule(pl.LightningDataModule):
         n_val = max(1, int(n_total * self.val_fraction))
         n_train = n_total - n_val
 
-        self.train_dataset, self._val_subset = random_split(
-            full_dataset, [n_train, n_val]
-        )
+        self.train_dataset, self._val_subset = random_split(full_dataset, [n_train, n_val])
 
         # The val subset wraps the same underlying dataset (set_name="train"),
         # meaning rotation augmentation still fires. We fix this by wrapping

--- a/src/floorplan_diffusion/training/lightning_module.py
+++ b/src/floorplan_diffusion/training/lightning_module.py
@@ -55,11 +55,9 @@ class FloorplanDiffusionModule(pl.LightningModule):
         self.analog_bit = analog_bit
 
         self.sampler = UniformSampler(diffusion)
-        
+
         # EMA parameters — a deep copy of model params stored as buffers.
-        self._ema_params: list[torch.Tensor] = [
-            p.clone().detach() for p in self.model.parameters()
-        ]
+        self._ema_params: list[torch.Tensor] = [p.clone().detach() for p in self.model.parameters()]
 
         self.save_hyperparameters(ignore=["model", "diffusion"])
 
@@ -67,7 +65,7 @@ class FloorplanDiffusionModule(pl.LightningModule):
     def on_train_start(self) -> None:
         """Called by Lightning when training begins (after moving to GPU)."""
         self._ema_params = [p.to(self.device) for p in self._ema_params]
-        
+
     # ------------------------------------------------------------------
     # Training
     # ------------------------------------------------------------------
@@ -128,7 +126,9 @@ class FloorplanDiffusionModule(pl.LightningModule):
     def configure_optimizers(self) -> dict[str, Any]:
         """AdamW optimizer with linear warmup and step-decay LR scheduling."""
         optimizer = torch.optim.AdamW(
-            self.model.parameters(), lr=self.lr, weight_decay=self.weight_decay,
+            self.model.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
         )
 
         if self.lr_decay_steps <= 0 and self.warmup_steps <= 0:

--- a/src/floorplan_diffusion/util/extract_data.py
+++ b/src/floorplan_diffusion/util/extract_data.py
@@ -1,5 +1,6 @@
-import zipfile
 import os
+import zipfile
+
 
 def extract_resplan():
     # Configuration
@@ -13,7 +14,7 @@ def extract_resplan():
         print(f"Created directory: {output_dir}")
 
     try:
-        with zipfile.ZipFile(zip_filename, 'r') as zip_ref:
+        with zipfile.ZipFile(zip_filename, "r") as zip_ref:
             # Check if the file exists within the zip
             if target_file in zip_ref.namelist():
                 # Extract only the specific file
@@ -21,11 +22,12 @@ def extract_resplan():
                 print(f"Successfully extracted '{target_file}' to '{output_dir}'.")
             else:
                 print(f"Error: '{target_file}' not found in {zip_filename}.")
-                
+
     except FileNotFoundError:
         print(f"Error: The file '{zip_filename}' was not found in the current directory.")
     except zipfile.BadZipFile:
         print(f"Error: '{zip_filename}' does not appear to be a valid zip file.")
+
 
 if __name__ == "__main__":
     extract_resplan()

--- a/tests/test_step7_validation.py
+++ b/tests/test_step7_validation.py
@@ -507,6 +507,12 @@ class TestTrainingLossesRuns:
 # Config and Trainer kwarg validation
 # ---------------------------------------------------------------------------
 
+_ALL_CONFIG_NAMES = [
+    "resplan_housediff_def.yaml",
+    "resplan_housediff_stable_fp32.yaml",
+    "resplan_housediff_test.yaml",
+]
+
 
 class TestValCheckIntervalConfig:
     """Verify all configs use step-based val_check_interval, not epoch-based."""
@@ -521,28 +527,14 @@ class TestValCheckIntervalConfig:
         with open(path) as f:
             return yaml.safe_load(f)
 
-    @pytest.mark.parametrize(
-        "config_name",
-        [
-            "resplan_housediff_def.yaml",
-            "resplan_housediff_stable_fp32.yaml",
-            "resplan_housediff_test.yaml",
-        ],
-    )
+    @pytest.mark.parametrize("config_name", _ALL_CONFIG_NAMES)
     def test_val_check_interval_present(self, config_name: str):
         cfg = self._load_config(config_name)
         assert "val_check_interval" in cfg["training"], (
             f"{config_name}: 'val_check_interval' key missing from training config"
         )
 
-    @pytest.mark.parametrize(
-        "config_name",
-        [
-            "resplan_housediff_def.yaml",
-            "resplan_housediff_stable_fp32.yaml",
-            "resplan_housediff_test.yaml",
-        ],
-    )
+    @pytest.mark.parametrize("config_name", _ALL_CONFIG_NAMES)
     def test_check_val_every_n_epoch_absent(self, config_name: str):
         cfg = self._load_config(config_name)
         assert "check_val_every_n_epoch" not in cfg["training"], (
@@ -571,14 +563,7 @@ class TestValCheckIntervalConfig:
             f"save_interval ({save_interval})"
         )
 
-    @pytest.mark.parametrize(
-        "config_name",
-        [
-            "resplan_housediff_def.yaml",
-            "resplan_housediff_stable_fp32.yaml",
-            "resplan_housediff_test.yaml",
-        ],
-    )
+    @pytest.mark.parametrize("config_name", _ALL_CONFIG_NAMES)
     def test_val_check_interval_is_positive_int(self, config_name: str):
         cfg = self._load_config(config_name)
         val_interval = cfg["training"]["val_check_interval"]

--- a/tests/test_step7_validation.py
+++ b/tests/test_step7_validation.py
@@ -23,16 +23,16 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "external" / "house_diffusion"))
 
-from src.floorplan_diffusion.data.dataset import ResPlanDataset
-from src.floorplan_diffusion.models.gaussian_diffusion import (
+from src.floorplan_diffusion.data.dataset import ResPlanDataset  # noqa: E402
+from src.floorplan_diffusion.models.gaussian_diffusion import (  # noqa: E402
     GaussianDiffusion,
     LossType,
     ModelMeanType,
     ModelVarType,
     get_named_beta_schedule,
 )
-from src.floorplan_diffusion.models.respace import SpacedDiffusion, space_timesteps
-from src.floorplan_diffusion.models.transformer import TransformerModel
+from src.floorplan_diffusion.models.respace import SpacedDiffusion, space_timesteps  # noqa: E402
+from src.floorplan_diffusion.models.transformer import TransformerModel  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -193,9 +193,7 @@ class TestDatasetMaskProperties:
         # living (0:4) <-> kitchen (8:12): connected.
         assert np.all(dm[0:4, 8:12] == 0)
         # bedroom (4:8) <-> kitchen (8:12): NOT connected, so door_mask=1.
-        assert np.all(dm[4:8, 8:12] == 1), (
-            "door_mask should be 1 between non-connected rooms"
-        )
+        assert np.all(dm[4:8, 8:12] == 1), "door_mask should be 1 between non-connected rooms"
 
 
 class TestDatasetCoordinateNormalization:
@@ -254,7 +252,7 @@ class TestTransformerIdentical:
         original.eval()
 
         # Synthetic inputs.
-        B, S = 2, 100
+        B, S = 2, 100  # noqa: N806
         th.manual_seed(0)
         x = th.randn(B, 2, S)
         timesteps = th.tensor([50, 100])
@@ -324,15 +322,23 @@ class TestDiffusionScheduleIdentical:
         orig_betas = orig_get_schedule(schedule, steps)
 
         np.testing.assert_allclose(
-            ported_betas, orig_betas, atol=1e-12,
+            ported_betas,
+            orig_betas,
+            atol=1e-12,
             err_msg=f"{schedule} beta schedules differ",
         )
 
     def test_diffusion_precomputed_arrays_identical(self):
         from house_diffusion.gaussian_diffusion import (
             GaussianDiffusion as OrigGaussianDiffusion,
+        )
+        from house_diffusion.gaussian_diffusion import (
             LossType as OrigLossType,
+        )
+        from house_diffusion.gaussian_diffusion import (
             ModelMeanType as OrigModelMeanType,
+        )
+        from house_diffusion.gaussian_diffusion import (
             ModelVarType as OrigModelVarType,
         )
 
@@ -374,8 +380,14 @@ class TestDiffusionScheduleIdentical:
     def test_q_sample_identical(self):
         from house_diffusion.gaussian_diffusion import (
             GaussianDiffusion as OrigGaussianDiffusion,
+        )
+        from house_diffusion.gaussian_diffusion import (
             LossType as OrigLossType,
+        )
+        from house_diffusion.gaussian_diffusion import (
             ModelMeanType as OrigModelMeanType,
+        )
+        from house_diffusion.gaussian_diffusion import (
             ModelVarType as OrigModelVarType,
         )
 
@@ -431,7 +443,7 @@ class TestTrainingLossesRuns:
             analog_bit=False,
         )
 
-        B, S = 2, 100
+        B, S = 2, 100  # noqa: N806
         x_start = th.randn(B, 2, S) * 0.5  # keep in reasonable range
 
         # Build conditioning.
@@ -477,9 +489,7 @@ class TestTrainingLossesRuns:
         }
 
         t = th.randint(0, 100, (B,))
-        terms = diffusion.training_losses(
-            model, x_start, t, model_kwargs, analog_bit=False
-        )
+        terms = diffusion.training_losses(model, x_start, t, model_kwargs, analog_bit=False)
 
         assert "loss" in terms, "training_losses must return 'loss' key"
         assert "mse_dec" in terms, "training_losses must return 'mse_dec' key"

--- a/tests/test_step7_validation.py
+++ b/tests/test_step7_validation.py
@@ -503,6 +503,123 @@ class TestTrainingLossesRuns:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Config and Trainer kwarg validation
+# ---------------------------------------------------------------------------
+
+
+class TestValCheckIntervalConfig:
+    """Verify all configs use step-based val_check_interval, not epoch-based."""
+
+    CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs"
+
+    def _load_config(self, name: str) -> dict:
+        import yaml
+
+        path = self.CONFIG_DIR / name
+        assert path.exists(), f"Config file not found: {path}"
+        with open(path) as f:
+            return yaml.safe_load(f)
+
+    @pytest.mark.parametrize(
+        "config_name",
+        [
+            "resplan_housediff_def.yaml",
+            "resplan_housediff_stable_fp32.yaml",
+            "resplan_housediff_test.yaml",
+        ],
+    )
+    def test_val_check_interval_present(self, config_name: str):
+        cfg = self._load_config(config_name)
+        assert "val_check_interval" in cfg["training"], (
+            f"{config_name}: 'val_check_interval' key missing from training config"
+        )
+
+    @pytest.mark.parametrize(
+        "config_name",
+        [
+            "resplan_housediff_def.yaml",
+            "resplan_housediff_stable_fp32.yaml",
+            "resplan_housediff_test.yaml",
+        ],
+    )
+    def test_check_val_every_n_epoch_absent(self, config_name: str):
+        cfg = self._load_config(config_name)
+        assert "check_val_every_n_epoch" not in cfg["training"], (
+            f"{config_name}: obsolete 'check_val_every_n_epoch' key still present"
+        )
+
+    @pytest.mark.parametrize(
+        "config_name,expected_interval",
+        [
+            ("resplan_housediff_def.yaml", 10000),
+            ("resplan_housediff_stable_fp32.yaml", 25000),
+            ("resplan_housediff_test.yaml", 250),
+        ],
+    )
+    def test_val_check_interval_aligned_with_save_interval(
+        self, config_name: str, expected_interval: int
+    ):
+        cfg = self._load_config(config_name)
+        val_interval = cfg["training"]["val_check_interval"]
+        save_interval = cfg["training"]["save_interval"]
+        assert val_interval == expected_interval, (
+            f"{config_name}: val_check_interval={val_interval}, expected {expected_interval}"
+        )
+        assert val_interval == save_interval, (
+            f"{config_name}: val_check_interval ({val_interval}) should equal "
+            f"save_interval ({save_interval})"
+        )
+
+    @pytest.mark.parametrize(
+        "config_name",
+        [
+            "resplan_housediff_def.yaml",
+            "resplan_housediff_stable_fp32.yaml",
+            "resplan_housediff_test.yaml",
+        ],
+    )
+    def test_val_check_interval_is_positive_int(self, config_name: str):
+        cfg = self._load_config(config_name)
+        val_interval = cfg["training"]["val_check_interval"]
+        assert isinstance(val_interval, int) and val_interval > 0, (
+            f"{config_name}: val_check_interval must be a positive int, got {val_interval!r}"
+        )
+
+
+def test_train_script_uses_val_check_interval():
+    """Verify train.py passes val_check_interval to Trainer (not check_val_every_n_epoch)."""
+    import ast
+
+    train_script = Path(__file__).resolve().parent.parent / "scripts" / "train.py"
+    source = train_script.read_text()
+    tree = ast.parse(source)
+
+    trainer_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "Trainer"
+    ]
+    assert trainer_calls, "Could not find pl.Trainer(...) call in scripts/train.py"
+
+    trainer_call = trainer_calls[0]
+    kwarg_names = {kw.arg for kw in trainer_call.keywords}
+
+    assert "val_check_interval" in kwarg_names, (
+        "pl.Trainer() call is missing 'val_check_interval' kwarg"
+    )
+    assert "check_val_every_n_epoch" not in kwarg_names, (
+        "pl.Trainer() still uses obsolete 'check_val_every_n_epoch' kwarg"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Checks 4-6: Deferred (require real data + GPU training)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.skip(reason="Requires ResPlan data and GPU training")
 def test_training_loss_decreases():
     """Check 4: Training loss decreases over time (model is learning)."""


### PR DESCRIPTION
## Summary

Validation was triggered at epoch boundaries (`check_val_every_n_epoch`) while every other interval in the system — checkpointing, logging, LR warmup, LR decay, and max training steps — is step-based. This caused the actual step count between validations to silently change whenever dataset size or batch size changed, making diagnostic logs unpredictable and inconsistent with the HouseDiffusion reference implementation.

**Root cause**: `scripts/train.py` passed `check_val_every_n_epoch` to `pl.Trainer` instead of `val_check_interval`.

## Changes

- **`scripts/train.py`**: Replace `check_val_every_n_epoch=train_cfg["check_val_every_n_epoch"]` with `val_check_interval=train_cfg["val_check_interval"]` in the `pl.Trainer` constructor.
- **`configs/resplan_housediff_def.yaml`**: Rename key and set `val_check_interval: 10000` (aligned with `save_interval`).
- **`configs/resplan_housediff_stable_fp32.yaml`**: Rename key and set `val_check_interval: 25000` (aligned with `save_interval`).
- **`configs/resplan_housediff_test.yaml`**: Rename key and set `val_check_interval: 250` (yields 2 validation runs over the 500-step smoke test).
- **Various files**: Ruff format and lint fixes (whitespace, import sort, `noqa` suppressions for conventional uppercase dimension names) applied to files touched by the core change.

## Validation

| Check | Result |
|-------|--------|
| `uv run ruff check src/ scripts/ tests/` | ✅ 0 errors |
| `uv run ruff format src/ scripts/ tests/` | ✅ clean |
| `uv run pytest tests/ -v` | ✅ 22 passed, 3 skipped, 0 failed |

The 3 skipped tests require trained model checkpoints or the full ResPlan dataset — expected in CI.

Fixes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Applied code formatting and style improvements across multiple files for better readability.
  * Reorganized imports and whitespace for consistency.

* **Tests**
  * Added validation tests to ensure training configurations consistently use step-based validation intervals.

* **Training Updates**
  * Transitioned validation scheduling from epoch-based to step-based intervals in all training configurations for more granular control during model training.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->